### PR TITLE
Dialplan updated: renamed XIVO_DSTID to WAZO_DSTID and XIVO_USERID to WAZO_USERID

### DIFF
--- a/spy.conf
+++ b/spy.conf
@@ -27,7 +27,7 @@
 
 [spy-call]
 exten = *556,1,Noop(Entering user defined context from-internal-custom in extensions_extra.d/spy.conf)
-same  =     n,Set(XIVO_DSTID=${XIVO_USERID})
+same  =     n,Set(WAZO_DSTID=${WAZO_USERID})
 same  =     n,AGI(agi://${XIVO_AGID_IP}/incoming_user_set_features)
 same  =     n,Read(spyee,please-enter-the&extension&number,,,20)
 same  =     n,Set(WAZO_EXTEN=${spyee})
@@ -36,7 +36,7 @@ same  =     n,AGI(/etc/asterisk/extensions_extra.d/interfaces.py)
 same  =     n,GoTo(targeted-chanspy,${WAZO_INTERFACES},1)
 
 exten = _*556.,1,NoOp(Entering user defined context from-internal-custom in extensions_custom.conf)
-same  =       n,Set(XIVO_DSTID=${XIVO_USERID})
+same  =       n,Set(WAZO_DSTID=${WAZO_USERID})
 same  =       n,AGI(agi://${XIVO_AGID_IP}/incoming_user_set_features)
 same  =       n,Set(WAZO_EXTEN=${EXTEN:4})
 same  =       n,Set(WAZO_CONTEXT=${WAZO_DST_USER_CONTEXT})


### PR DESCRIPTION
Dialplan updated: renamed XIVO_DSTID to WAZO_DSTID and XIVO_USERID to WAZO_USERID